### PR TITLE
Update Podfile to use the new cocoapods cdn

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://cdn.cocoapods.org/'
 
 platform :ios, "9.0"
 


### PR DESCRIPTION
The `pod install` command is notoriously slow when first fetching the specs repo.

CocoaPods [recently released a cdn](https://blog.cocoapods.org/CocoaPods-1.7.2/) that serves specs faster. Using their cdn, restoring pods no longer takes my Mac longer than actually building the project. It's an improvement for new contributors.