### PR TITLE
Fixed the Xcode 13 builds for iOS 15

### DIFF
--- a/GBA4iOS/GBAAppDelegate.mm
+++ b/GBA4iOS/GBAAppDelegate.mm
@@ -94,7 +94,7 @@ static GBAAppDelegate *_appDelegate;
     
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone)
     {
-        self.emulationViewController = [[GBAEmulationViewController alloc] init];
+        self.emulationViewController = [GBAEmulationViewController controller];
         
         self.window.rootViewController = self.emulationViewController;
     }
@@ -461,7 +461,7 @@ void applicationDidCrash(siginfo_t *info, ucontext_t *uap, void *context)
         return;
     }
     
-    GBASoftwareUpdateViewController *softwareUpdateViewController = [[GBASoftwareUpdateViewController alloc] initWithSoftwareUpdate:softwareUpdate];
+    GBASoftwareUpdateViewController *softwareUpdateViewController = [GBASoftwareUpdateViewController controllerWithSoftwareUpdate:softwareUpdate];
     
     UIBarButtonItem *cancelButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(dismissPresentedViewController:)];
     softwareUpdateViewController.navigationItem.leftBarButtonItem = cancelButton;

--- a/GBA4iOS/GBACheatEditorViewController.h
+++ b/GBA4iOS/GBACheatEditorViewController.h
@@ -22,6 +22,10 @@
 
 @interface GBACheatEditorViewController : UITableViewController
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
++ (instancetype)controller;
+
 @property (weak, nonatomic) id<GBACheatEditorViewControllerDelegate> delegate;
 @property (strong, nonatomic) GBACheat *cheat;
 @property (assign, nonatomic) GBAROMType romType;

--- a/GBA4iOS/GBACheatEditorViewController.m
+++ b/GBA4iOS/GBACheatEditorViewController.m
@@ -51,16 +51,16 @@ CGFloat GBATextViewInsetDefaultRight = 6;
 
 @implementation GBACheatEditorViewController
 
-- (id)init
++ (instancetype)controller
 {
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Emulation" bundle:nil];
     
-    self = [storyboard instantiateViewControllerWithIdentifier:@"cheatEditorViewController"];
-    if (self)
+    GBACheatEditorViewController *controller = [storyboard instantiateViewControllerWithIdentifier:@"cheatEditorViewController"];
+    if (controller)
     {
-        _presenting = YES;
+        controller->_presenting = YES;
     }
-    return self;
+    return controller;
 }
 
 - (void)viewDidLoad

--- a/GBA4iOS/GBACheatManagerViewController.mm
+++ b/GBA4iOS/GBACheatManagerViewController.mm
@@ -167,7 +167,7 @@
 
 - (void)tappedAddCheatCode:(UIBarButtonItem *)button
 {
-    GBACheatEditorViewController *cheatEditorViewController = [[GBACheatEditorViewController alloc] init];
+    GBACheatEditorViewController *cheatEditorViewController = [GBACheatEditorViewController controller];
     cheatEditorViewController.romType = self.rom.type;
     cheatEditorViewController.delegate = self;
     
@@ -396,7 +396,7 @@
     
     if ([self.tableView isEditing])
     {
-        GBACheatEditorViewController *cheatEditorViewController = [[GBACheatEditorViewController alloc] init];
+        GBACheatEditorViewController *cheatEditorViewController = [GBACheatEditorViewController controller];
         cheatEditorViewController.romType = self.rom.type;
         cheatEditorViewController.cheat = cheat;
         cheatEditorViewController.delegate = self;

--- a/GBA4iOS/GBAClassicSplitViewController.m
+++ b/GBA4iOS/GBAClassicSplitViewController.m
@@ -30,11 +30,11 @@
         
         self.romTableViewControllerIsVisible = NO;
         
-        self.romTableViewController = [[GBAROMTableViewController alloc] init];
+        self.romTableViewController = [GBAROMTableViewController controller];
         self.romTableViewController.appearanceDelegate = self;
         UINavigationController *navigationController = RST_CONTAIN_IN_NAVIGATION_CONTROLLER(self.romTableViewController);
         
-        self.emulationViewController = [[GBAEmulationViewController alloc] init];
+        self.emulationViewController = [GBAEmulationViewController controller];
         
         self.viewControllers = @[navigationController, self.emulationViewController];
         

--- a/GBA4iOS/GBAColorSelectionViewController.h
+++ b/GBA4iOS/GBAColorSelectionViewController.h
@@ -27,6 +27,10 @@ typedef NS_ENUM(NSInteger, GBCColorPalette)
 
 @interface GBAColorSelectionViewController : UITableViewController
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
++ (instancetype)controller;
+
 + (NSString *)localizedNameForGBCColorPalette:(GBCColorPalette)colorPalette;
 
 @end

--- a/GBA4iOS/GBAColorSelectionViewController.m
+++ b/GBA4iOS/GBAColorSelectionViewController.m
@@ -15,16 +15,11 @@
 
 @implementation GBAColorSelectionViewController
 
-- (instancetype)init
++ (instancetype)controller
 {
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Settings" bundle:nil];
-    self = [storyboard instantiateViewControllerWithIdentifier:@"colorSelectionViewController"];
-    if (self)
-    {
-        // Custom initialization
-    }
-    
-    return self;
+    GBAColorSelectionViewController *controller = [storyboard instantiateViewControllerWithIdentifier:@"colorSelectionViewController"];
+    return controller;
 }
 
 - (void)viewDidLoad

--- a/GBA4iOS/GBAEmulationViewController.h
+++ b/GBA4iOS/GBAEmulationViewController.h
@@ -15,6 +15,10 @@
 @property (assign, nonatomic) CGFloat blurAlpha;
 @property (strong, nonatomic) UIImageView *blurredContentsImageView;
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
++ (instancetype)controller;
+
 - (void)showSplashScreen;
 
 - (void)blurWithInitialAlpha:(CGFloat)alpha;

--- a/GBA4iOS/GBAEmulationViewController.mm
+++ b/GBA4iOS/GBAEmulationViewController.mm
@@ -101,20 +101,20 @@ static GBAEmulationViewController *_emulationViewController;
 
 #pragma mark - UIViewController subclass
 
-- (instancetype)init
++ (instancetype)controller
 {
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Emulation" bundle:nil];
-    self = [storyboard instantiateViewControllerWithIdentifier:@"emulationViewController"];
-    if (self)
+    GBAEmulationViewController *controller = [storyboard instantiateViewControllerWithIdentifier:@"emulationViewController"];
+    if (controller)
     {
-        _launchingApplication = YES;
+        controller->_launchingApplication = YES;
         
-        _emulationViewController = self;
+        _emulationViewController = controller;
         
-        [[GBAEmulatorCore sharedCore] setDelegate:self];
+        [[GBAEmulatorCore sharedCore] setDelegate:controller];
     }
     
-    return self;
+    return controller;
 }
 
 - (void)viewDidLoad
@@ -201,7 +201,7 @@ static GBAEmulationViewController *_emulationViewController;
         // Add to our view so we can animate it
         [self.view addSubview:self.splashScreenView];
         
-        self.romTableViewController = [[GBAROMTableViewController alloc] initWithNibName:nil bundle:nil];
+        self.romTableViewController = [GBAROMTableViewController controller];
         self.romTableViewController.appearanceDelegate = self;
         self.romTableViewController.view.layer.allowsGroupOpacity = YES;
         

--- a/GBA4iOS/GBAEventDistributionDetailViewController.h
+++ b/GBA4iOS/GBAEventDistributionDetailViewController.h
@@ -30,7 +30,8 @@
 
 @property (weak, nonatomic) id <GBAEventDistributionDetailViewControllerDelegate> delegate;
 
-
-- (instancetype)initWithEvent:(GBAEvent *)event;
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
++ (instancetype)controllerWithEvent:(GBAEvent *)event;
 
 @end

--- a/GBA4iOS/GBAEventDistributionDetailViewController.m
+++ b/GBA4iOS/GBAEventDistributionDetailViewController.m
@@ -24,22 +24,22 @@
 
 @implementation GBAEventDistributionDetailViewController
 
-- (instancetype)initWithEvent:(GBAEvent *)event
++ (instancetype)controllerWithEvent:(GBAEvent *)event
 {
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Emulation" bundle:nil];
-    self = [storyboard instantiateViewControllerWithIdentifier:@"eventDistributionDetailViewController"];
-    if (self)
+    GBAEventDistributionDetailViewController *controller = [storyboard instantiateViewControllerWithIdentifier:@"eventDistributionDetailViewController"];
+    if (controller)
     {
-        _event = event;
-        self.title = event.name;
+        controller->_event = event;
     }
-    return self;
+    return controller;
 }
 
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-            
+
+    self.title = self.event.name;
     self.detailTextView.text = self.event.eventDescription;;
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(contentSizeCategoryDidChange:) name:UIContentSizeCategoryDidChangeNotification object:nil];

--- a/GBA4iOS/GBAEventDistributionViewController.mm
+++ b/GBA4iOS/GBAEventDistributionViewController.mm
@@ -525,7 +525,7 @@ static void * GBADownloadProgressTotalUnitContext = &GBADownloadProgressTotalUni
     
     if ([[NSFileManager defaultManager] fileExistsAtPath:eventFilepath])
     {
-        GBAEventDistributionDetailViewController *eventDistributionDetailViewController = [[GBAEventDistributionDetailViewController alloc] initWithEvent:event];
+        GBAEventDistributionDetailViewController *eventDistributionDetailViewController = [GBAEventDistributionDetailViewController controllerWithEvent:event];
         eventDistributionDetailViewController.delegate = self;
         eventDistributionDetailViewController.imageCache = self.imageCache;
         eventDistributionDetailViewController.rom = self.rom;

--- a/GBA4iOS/GBAExternalControllerCustomizationViewController.h
+++ b/GBA4iOS/GBAExternalControllerCustomizationViewController.h
@@ -10,4 +10,8 @@
 
 @interface GBAExternalControllerCustomizationViewController : UIViewController
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
++ (instancetype)controller;
+
 @end

--- a/GBA4iOS/GBAExternalControllerCustomizationViewController.m
+++ b/GBA4iOS/GBAExternalControllerCustomizationViewController.m
@@ -54,29 +54,27 @@ SMCalloutAnimation SMCalloutAnimationNone = 18;
 
 @implementation GBAExternalControllerCustomizationViewController
 
-- (id)init
++ (instancetype)controller
 {
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Settings" bundle:nil];
-    self = [storyboard instantiateViewControllerWithIdentifier:@"externalControllerCustomizationViewController"];
-    if (self)
+    GBAExternalControllerCustomizationViewController *controller = [storyboard instantiateViewControllerWithIdentifier:@"externalControllerCustomizationViewController"];
+    if (controller)
     {
-        _calloutViewButtonA = [GBACalloutView new];
-        _calloutViewButtonB = [GBACalloutView new];
-        _calloutViewButtonX = [GBACalloutView new];
-        _calloutViewButtonY = [GBACalloutView new];
-        _calloutViewButtonL2 = [GBACalloutView new];
-        _calloutViewButtonR2 = [GBACalloutView new];
+        controller->_calloutViewButtonA = [GBACalloutView new];
+        controller->_calloutViewButtonB = [GBACalloutView new];
+        controller->_calloutViewButtonX = [GBACalloutView new];
+        controller->_calloutViewButtonY = [GBACalloutView new];
+        controller->_calloutViewButtonL2 = [GBACalloutView new];
+        controller->_calloutViewButtonR2 = [GBACalloutView new];
         
-        _calloutViewButtonA.interactionDelegate = self;
-        _calloutViewButtonB.interactionDelegate = self;
-        _calloutViewButtonX.interactionDelegate = self;
-        _calloutViewButtonY.interactionDelegate = self;
-        _calloutViewButtonL2.interactionDelegate = self;
-        _calloutViewButtonR2.interactionDelegate = self;
-        
-        [self updateCalloutViews];
+        controller->_calloutViewButtonA.interactionDelegate = controller;
+        controller->_calloutViewButtonB.interactionDelegate = controller;
+        controller->_calloutViewButtonX.interactionDelegate = controller;
+        controller->_calloutViewButtonY.interactionDelegate = controller;
+        controller->_calloutViewButtonL2.interactionDelegate = controller;
+        controller->_calloutViewButtonR2.interactionDelegate = controller;
     }
-    return self;
+    return controller;
 }
 
 - (void)viewDidLoad
@@ -86,6 +84,8 @@ SMCalloutAnimation SMCalloutAnimationNone = 18;
     
     self.view.backgroundColor = [UIColor groupTableViewBackgroundColor];
     self.buttonLayoutView.backgroundColor = [UIColor groupTableViewBackgroundColor];
+
+    [self updateCalloutViews];
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/GBA4iOS/GBAModernSplitViewController.m
+++ b/GBA4iOS/GBAModernSplitViewController.m
@@ -26,8 +26,8 @@
         
         self.preferredDisplayMode = UISplitViewControllerDisplayModePrimaryOverlay;
         
-        self.romTableViewController = [[GBAROMTableViewController alloc] initWithNibName:nil bundle:nil];
-        self.emulationViewController = [[GBAEmulationViewController alloc] init];
+        self.romTableViewController = [GBAROMTableViewController controller];
+        self.emulationViewController = [GBAEmulationViewController controller];
         
         GBAMasterNavigationController *navigationController = [[GBAMasterNavigationController alloc] initWithRootViewController:self.romTableViewController];
         

--- a/GBA4iOS/GBAPushNotificationsViewController.h
+++ b/GBA4iOS/GBAPushNotificationsViewController.h
@@ -10,4 +10,8 @@
 
 @interface GBAPushNotificationsViewController : UITableViewController
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
++ (instancetype)controller;
+
 @end

--- a/GBA4iOS/GBAPushNotificationsViewController.m
+++ b/GBA4iOS/GBAPushNotificationsViewController.m
@@ -17,15 +17,11 @@
 
 @implementation GBAPushNotificationsViewController
 
-- (id)init
++ (instancetype)controller
 {
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Settings" bundle:nil];
-    self = [storyboard instantiateViewControllerWithIdentifier:@"pushNotificationsViewController"];
-    if (self)
-    {
-        // Custom initialization
-    }
-    return self;
+    GBAPushNotificationsViewController *controller = [storyboard instantiateViewControllerWithIdentifier:@"pushNotificationsViewController"];
+    return controller;
 }
 
 - (void)viewDidLoad

--- a/GBA4iOS/GBAROMTableViewController.h
+++ b/GBA4iOS/GBAROMTableViewController.h
@@ -27,6 +27,10 @@
 @property (weak, nonatomic) id<GBAROMTableViewControllerAppearanceDelegate> appearanceDelegate;
 @property (weak, nonatomic) GBAEmulationViewController *emulationViewController;
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
++ (instancetype)controller;
+
 - (void)startROM:(GBAROM *)rom;
 
 @end

--- a/GBA4iOS/GBAROMTableViewController.mm
+++ b/GBA4iOS/GBAROMTableViewController.mm
@@ -85,34 +85,25 @@ dispatch_queue_t directoryContentsChangedQueue() {
     return queue;
 }
 
-- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
++ (instancetype)controller
 {
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Emulation" bundle:nil];
-    self = [storyboard instantiateViewControllerWithIdentifier:@"romTableViewController"];
-    if (self)
-    {
-        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-        NSString *documentsDirectory = ([paths count] > 0) ? [paths objectAtIndex:0] : nil;
+    GBAROMTableViewController *controller = [storyboard instantiateViewControllerWithIdentifier:@"romTableViewController"];
+
+    if (controller) {
+        controller->_downloadProgress = [[NSProgress alloc] initWithParent:nil userInfo:nil];
+        [controller->_downloadProgress addObserver:controller
+                            forKeyPath:@"fractionCompleted"
+                               options:NSKeyValueObservingOptionNew
+                               context:GBADownloadROMProgressContext];
         
-        self.currentDirectory = documentsDirectory; 
-        self.showFileExtensions = YES;
-        self.showFolders = NO;
-        self.showSectionTitles = YES;
-        self.showUnavailableFiles = YES;
+        controller->_currentDownloadsDictionary = [NSMutableDictionary dictionary];
         
-        _downloadProgress = [[NSProgress alloc] initWithParent:nil userInfo:nil];
-        [_downloadProgress addObserver:self
-                    forKeyPath:@"fractionCompleted"
-                       options:NSKeyValueObservingOptionNew
-                       context:GBADownloadROMProgressContext];
-        
-        _currentDownloadsDictionary = [NSMutableDictionary dictionary];
-        
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(userRequestedToPlayROM:) name:GBAUserRequestedToPlayROMNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidHide:) name:UIKeyboardDidHideNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(settingsDidChange:) name:GBASettingsDidChangeNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:controller selector:@selector(userRequestedToPlayROM:) name:GBAUserRequestedToPlayROMNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:controller selector:@selector(keyboardDidHide:) name:UIKeyboardDidHideNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:controller selector:@selector(settingsDidChange:) name:GBASettingsDidChangeNotification object:nil];
     }
-    return self;
+    return controller;
 }
 
 - (void)dealloc
@@ -131,7 +122,16 @@ dispatch_queue_t directoryContentsChangedQueue() {
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-	// Do any additional setup after loading the view.
+    // Do any additional setup after loading the view.
+
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString *documentsDirectory = ([paths count] > 0) ? [paths objectAtIndex:0] : nil;
+
+    self.currentDirectory = documentsDirectory;
+    self.showFileExtensions = YES;
+    self.showFolders = NO;
+    self.showSectionTitles = YES;
+    self.showUnavailableFiles = YES;
     
     self.clearsSelectionOnViewWillAppear = YES;
     
@@ -1577,7 +1577,7 @@ dispatch_queue_t directoryContentsChangedQueue() {
 
 - (IBAction)presentSettings:(UIBarButtonItem *)barButtonItem
 {
-    GBASettingsViewController *settingsViewController = [[GBASettingsViewController alloc] init];
+    GBASettingsViewController *settingsViewController = [GBASettingsViewController controller];
     settingsViewController.delegate = self;
     
     [[UIApplication sharedApplication] setStatusBarStyle:[settingsViewController preferredStatusBarStyle] animated:YES];

--- a/GBA4iOS/GBASettingsViewController.h
+++ b/GBA4iOS/GBASettingsViewController.h
@@ -51,6 +51,10 @@ static NSString *GBASettingsRememberLastWebpageKey = @"rememberLastWebpage";
 
 @property (weak, nonatomic) id<GBASettingsViewControllerDelegate> delegate;
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
++ (instancetype)controller;
+
 + (void)registerDefaults;
 
 @end

--- a/GBA4iOS/GBASettingsViewController.m
+++ b/GBA4iOS/GBASettingsViewController.m
@@ -78,15 +78,11 @@ NSString *const GBASettingsDropboxStatusChangedNotification = @"GBASettingsDropb
 
 @implementation GBASettingsViewController
 
-- (id)init
++ (instancetype)controller
 {
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Settings" bundle:nil];
-    self = [storyboard instantiateViewControllerWithIdentifier:@"settingsViewController"];
-    if (self)
-    {
-        // Custom initialization
-    }
-    return self;
+    GBASettingsViewController *controller = [storyboard instantiateViewControllerWithIdentifier:@"settingsViewController"];
+    return controller;
 }
 
 - (void)viewDidLoad
@@ -420,19 +416,19 @@ NSString *const GBASettingsDropboxStatusChangedNotification = @"GBASettingsDropb
     }
     else if (indexPath.section == PUSH_NOTIFICATIONS_SECTION)
     {
-        GBAPushNotificationsViewController *pushNotificationsViewController = [GBAPushNotificationsViewController new];
+        GBAPushNotificationsViewController *pushNotificationsViewController = [GBAPushNotificationsViewController controller];
         [self.navigationController pushViewController:pushNotificationsViewController animated:YES];
     }
     else if (indexPath.section == ORIGINAL_GAMEBOY_SECTION)
     {
-        GBAColorSelectionViewController *colorSelectionViewController = [GBAColorSelectionViewController new];
+        GBAColorSelectionViewController *colorSelectionViewController = [GBAColorSelectionViewController controller];
         [self.navigationController pushViewController:colorSelectionViewController animated:YES];
     }
     else if (indexPath.section == WEB_BROWSER_SECTION)
     {
         if (indexPath.row == 0)
         {
-            GBAWebBrowserHomepageViewController *homepageViewController = [GBAWebBrowserHomepageViewController new];
+            GBAWebBrowserHomepageViewController *homepageViewController = [GBAWebBrowserHomepageViewController controller];
             [self.navigationController pushViewController:homepageViewController animated:YES];
         }
     }
@@ -453,7 +449,7 @@ NSString *const GBASettingsDropboxStatusChangedNotification = @"GBASettingsDropb
     }
     else if (indexPath.section == EXTERNAL_CONTROLLER_SECTION)
     {
-        GBAExternalControllerCustomizationViewController *externalControllerCustomizationViewController = [[GBAExternalControllerCustomizationViewController alloc] init];
+        GBAExternalControllerCustomizationViewController *externalControllerCustomizationViewController = [GBAExternalControllerCustomizationViewController controller];
         
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad)
         {
@@ -477,7 +473,7 @@ NSString *const GBASettingsDropboxStatusChangedNotification = @"GBASettingsDropb
     }
     else if (indexPath.section == SOFTWARE_UPDATE_SECTION)
     {
-        GBASoftwareUpdateViewController *softwareUpdateViewController = [[GBASoftwareUpdateViewController alloc] init];
+        GBASoftwareUpdateViewController *softwareUpdateViewController = [GBASoftwareUpdateViewController controller];
         [self.navigationController pushViewController:softwareUpdateViewController animated:YES];
     }
     else if (indexPath.section == CREDITS_SECTION)

--- a/GBA4iOS/GBASoftwareUpdateViewController.h
+++ b/GBA4iOS/GBASoftwareUpdateViewController.h
@@ -12,6 +12,9 @@
 
 @interface GBASoftwareUpdateViewController : UITableViewController
 
-- (instancetype)initWithSoftwareUpdate:(GBASoftwareUpdate *)softwareUpdate;
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
++ (instancetype)controller;
++ (instancetype)controllerWithSoftwareUpdate:(GBASoftwareUpdate *)softwareUpdate;
 
 @end

--- a/GBA4iOS/GBASoftwareUpdateViewController.m
+++ b/GBA4iOS/GBASoftwareUpdateViewController.m
@@ -28,21 +28,21 @@
 
 @implementation GBASoftwareUpdateViewController
 
-- (instancetype)init
++ (instancetype)controller
 {
-    return [self initWithSoftwareUpdate:nil];
+    return [self controllerWithSoftwareUpdate:nil];
 }
 
-- (instancetype)initWithSoftwareUpdate:(GBASoftwareUpdate *)softwareUpdate
++ (instancetype)controllerWithSoftwareUpdate:(GBASoftwareUpdate *)softwareUpdate
 {
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Settings" bundle:nil];
-    self = [storyboard instantiateViewControllerWithIdentifier:@"softwareUpdateViewController"];
-    if (self)
+    GBASoftwareUpdateViewController *controller = [storyboard instantiateViewControllerWithIdentifier:@"softwareUpdateViewController"];
+    if (controller)
     {
-        _softwareUpdate = softwareUpdate;
+        controller->_softwareUpdate = softwareUpdate;
     }
     
-    return self;
+    return controller;
 }
 
 - (void)viewDidLoad

--- a/GBA4iOS/GBAWebBrowserHomepageViewController.h
+++ b/GBA4iOS/GBAWebBrowserHomepageViewController.h
@@ -20,6 +20,10 @@ typedef NS_ENUM(NSInteger, GBAWebBrowserHomepage)
 
 @interface GBAWebBrowserHomepageViewController : UITableViewController
 
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
++ (instancetype)controller;
+
 + (NSString *)localizedNameForWebBrowserHomepage:(GBAWebBrowserHomepage)webBrowserHomepage;
 
 @end

--- a/GBA4iOS/GBAWebBrowserHomepageViewController.m
+++ b/GBA4iOS/GBAWebBrowserHomepageViewController.m
@@ -17,16 +17,11 @@
 
 @implementation GBAWebBrowserHomepageViewController
 
-- (instancetype)init
++ (instancetype)controller
 {
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Settings" bundle:nil];
-    self = [storyboard instantiateViewControllerWithIdentifier:@"webBrowserHomepageViewController"];
-    if (self)
-    {
-        
-    }
-    
-    return self;
+    GBAWebBrowserHomepageViewController *controller = [storyboard instantiateViewControllerWithIdentifier:@"webBrowserHomepageViewController"];
+    return controller;
 }
 
 - (void)viewDidLoad


### PR DESCRIPTION
Xcode 13 builds for iOS 15 are not working well with the instance constructors (with '-'), crashing the application with the following message:

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'UIViewController is missing 
its initial trait collection populated during initialization. This is 
a serious bug, likely caused by accessing properties or methods on the 
view controller before calling a UIViewController initializer. View 
controller: <CustomViewController: 0xXXXXXXXXXXXX>'
```

 Switching to class constructors (with '+') does the job.

[Here are](https://stackoverflow.com/questions/69092599/xcode-13-beta-5-error-uiviewcontroller-is-missing-its-initial-trait-collection) some discussions on the point.

- Done the needed changes in all the storyboard-based constructors.
- Checked that the application is running as expected now.
- Made the default constructors unavailable, just to be sure that they are not called from anywhere.
- Also, moved a few lines of code from `init`'s to `viewDidLoad`'s of the changed classes in cases when the value assignment via ivars did not work.